### PR TITLE
Fix zombie interaction with plants

### DIFF
--- a/Game.java
+++ b/Game.java
@@ -281,9 +281,17 @@ public class Game {
 
         for (Zombie z : movingZombies) {
             z.attack();
-            if (!justSpawned.contains(z) && ticks % z.getSpeed() == 0) {
-                z.move(board);
+
+            // Only move if there is no living plant on the current tile
+            Tile current = z.getPosition();
+            Plant occupant = current.getPlant();
+
+            if (occupant == null) {
+                if (!justSpawned.contains(z) && ticks % z.getSpeed() == 0) {
+                    z.move(board);
+                }
             }
+
             if (z.getPosition().getColumn() == 0) {
                 System.out.println("A zombie reached your house! Game Over. Zombies win!");
                 return true;

--- a/zombies/Zombie.java
+++ b/zombies/Zombie.java
@@ -98,11 +98,17 @@ public abstract class Zombie {
      */
     public void attack() {
         Tile currentTile = this.getPosition();
-        if (currentTile.getPlant() != null) {
-            currentTile.getPlant().takeDamage(this);
+        Plant target = currentTile.getPlant();
+        if (target != null) {
+            target.takeDamage(this);
             System.out.println("Zombie at Row " + (currentTile.getRow() + 1) + ", Col " +
                     (currentTile.getColumn() + 1) + " attacked the plant for " + this.getDamage() +
                     " damage.");
+            if (!target.isAlive()) {
+                currentTile.removePlants();
+                System.out.println("Plant at Row " + (currentTile.getRow() + 1) + ", Col " +
+                        (currentTile.getColumn() + 1) + " was destroyed.");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- ensure zombies destroy plants when they die
- stop zombies from moving past a tile containing a plant
