### PR TITLE
Limit peashooter attack to single zombie per tick

### DIFF
--- a/Game.java
+++ b/Game.java
@@ -230,16 +230,17 @@ public class Game {
                 if (p instanceof Peashooter) {
                     for (int zc = c + 1; zc < COLS && zc <= c + p.getRange(); zc++) {
                         if (board[r][zc].hasZombies()) {
-                            List<Zombie> zs = new ArrayList<>(board[r][zc].getZombies());
-                            for (Zombie z : zs) {
-                                p.action(z);
-                                if (!z.isAlive()) {
-                                    board[r][zc].removeZombie(z);
+                            List<Zombie> zs = board[r][zc].getZombies();
+                            if (!zs.isEmpty()) {
+                                Zombie target = zs.get(0);
+                                p.action(target);
+                                if (!target.isAlive()) {
+                                    board[r][zc].removeZombie(target);
                                     System.out.println(
                                             "Zombie at Row " + (r + 1) + " Col " + (zc + 1) + " died.");
                                 }
                             }
-                            break;
+                            break; // attack only one zombie on the first tile in range
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- peashooter now targets only the first zombie on the first tile in range

## Testing
- `javac *.java plants/*.java zombies/*.java tiles/*.java`


------
https://chatgpt.com/codex/tasks/task_b_68595bb1b2288320b1a507746d4a32f8